### PR TITLE
Switch to reStructuredText README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,18 +7,18 @@ This python package provides the ManageIQ API Client library.
 Getting Started
 ---------------
 
-Preparing your python virtual environment:
+Preparing your python virtual environment::
 
     $ virtualenv venv
     $ source venv/bin/activate
     $ pip install -e .  # To create an editable install of this package
 
-If you want to install it directly from GitHub:
+If you want to install it directly from GitHub::
 
     $ pip install git+https://github.com/ManageIQ/manageiq-api-client-python.git
 
 To run the example present in this repository you probably need to configure
-your options (if different from the default shown here):
+your options (if different from the default shown here)::
 
     $ export MIQURL=http://localhost:3000/api
     $ export MIQUSERNAME=admin


### PR DESCRIPTION
PyPI doesn't render markdown, it parses README.md assuming reST rules:
https://github.com/pypa/pypi-legacy/issues/148
(after 2 years and several attempts, there's still no agreement on right fix)

This currently causes joined lines on
https://pypi.python.org/pypi/manageiq-api-client-python/

There are some workarounds to get README.md working using automatic
translation, but just simplest is just switching to README.rst with reST syntax.
(especially since in this case it's just a couple chars difference)

Rendered README.rst: https://github.com/cben/manageiq-api-client-python/blob/4bedcb08103b56b659218e70344a3ea146b23ef7/README.rst