### PR TITLE
Adding support for OPTIONS, query strings, HTTP method overriding; fixing handling of "count", "subcount" and "href"

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -118,7 +118,7 @@ class ManageIQClient(object):
     def options(self, url, **opt_params):
         self.logger.info("[RESTAPI] OPTIONS %s %r", url, opt_params)
         data = self._sending_request(
-            partial(self._session.options, url, params=opt_params, verify=False))
+            partial(self._session.options, url, params=opt_params))
         try:
             data = data.json()
         except simplejson.scanner.JSONDecodeError:


### PR DESCRIPTION
* added support for OPTIONS http method
* fixed "count" and "subcount" handling when collection is missing one of these fields (e.g. /api/automate)
* added possibility to use query string (for e.g. /api/automate?depth=-1&search_options=state_machines)
* fixed handling of resources that are missing "href" but have "id" (e.g. /api/automate)
* added possibility to override HTTP method (e.g. to use DELETE instead of POST)