### PR TITLE
handle null results in _process_result

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -570,7 +570,7 @@ class Action(object):
         if result is None:
             return None
         elif "results" in result:
-            return map(self._process_result, result["results"])
+            return [self._process_result(res) for res in result["results"] if res]
         else:
             return self._process_result(result)
 

--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -570,12 +570,14 @@ class Action(object):
         if result is None:
             return None
         elif "results" in result:
-            return [self._process_result(res) for res in result["results"] if res]
+            return map(self._process_result, result["results"])
         else:
             return self._process_result(result)
 
     def _process_result(self, result):
-        if "href" in result:
+        if result is None:
+            return None
+        elif "href" in result:
             return Entity(self.collection, result, incomplete=True)
         elif "id" in result:
             d = copy(result)


### PR DESCRIPTION
Result from some collections (e.g. `/api/orchestration_templates`) can be null.
For e.g.
```
POST /api/orchestration_templates
{
  "action" : "delete",
  "resources" : [
    { "href" : "https://<address>/api/orchestration_templates/137" },
    { "href" : "https://<address>/api/orchestration_templates/138" }
  ]
}

```
the result is
```
{
  "results": [
    null,
    null
  ]
}
```

Currently it leads to following error:
```
    def _process_result(self, result):
>       if "href" in result:
E       TypeError: argument of type 'NoneType' is not iterable
```
My change adds handling of null results to `_process_result`.