### PR TITLE
suppress repeated InsecureRequestWarning warnings

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # TODO: WIP WIP WIP WIP!
 # I got another stage of this library aside, but this is perfectly usable with some restrictions :)
-import iso8601
 import json
 import logging
 import re
+import warnings
 import requests
 import simplejson
 import six
+import iso8601
 from copy import copy
 from distutils.version import LooseVersion
 from functools import partial
@@ -33,6 +34,7 @@ class ManageIQClient(object):
         self._session = requests.Session()
         if not verify_ssl:
             self._session.verify = False
+            warnings.filterwarnings('once', message='.*Unverified HTTPS request.*')
         elif ca_bundle_path:
             self._session.verify = ca_bundle_path
         self._session.auth = self._auth


### PR DESCRIPTION
The warning
`.../lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:843: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)`
is printed every time any requests is made when `verify_ssl=False`.
This makes e.g. interactive use in ipython chaotic. Printing this once is enough.

I chose to suppress the warning using the message string instead of using the warning category. The `urllib3` module responsible for this message is bundled with `requests` module and we are not using it directly, only through `requests`. I don't like doing
```
from requests.packages.urllib3.exceptions import InsecureRequestWarning
```
IMHO suppressing the warning using just the message string lets us worry a little less about being broken later.