### PR TITLE
Auth token support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,14 @@ To generate a temporary miq token from the MIQ Dev environment use the following
 
     $ bin/rails r 'puts Api::UserTokenService.new.generate_token("admin","api")'
 
+To run tests locally in a Dev Environment::
+
+    $ sudo pip install tox
+    $ tox # this will run tests on all versions of python
+    $ tox -e py27 -- -x testing/test_api_credentials.py # just on python 2.7
+
+
+
 Legal
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ Getting Started
 
 Preparing your python virtual environment::
 
+    $ sudo pip install virtualenv
     $ virtualenv venv
     $ source venv/bin/activate
     $ pip install -e .  # To create an editable install of this package
@@ -23,9 +24,13 @@ your options (if different from the default shown here)::
     $ export MIQURL=http://localhost:3000/api
     $ export MIQUSERNAME=admin
     $ export MIQPASSWORD=smartvm
+    $ export MIQTOKEN=<<miq_ephemeral_token>>
 
     $ python example.py
 
+To generate a temporary miq token from the MIQ Dev environment use the following command::
+
+    $ bin/rails r 'puts Api::UserTokenService.new.generate_token("admin","api")'
 
 Legal
 -----

--- a/example.py
+++ b/example.py
@@ -2,10 +2,15 @@ import os
 from manageiq_client.api import ManageIQClient as MiqApi
 
 url = os.environ.get('MIQURL') or 'http://localhost:3000/api'
-username = os.environ.get('MIQUSERNAME') or 'admin'
-password = os.environ.get('MIQPASSWORD') or 'smartvm'
+auth = {}
+if os.environ.has_key("MIQTOKEN"):
+    auth['x-auth-token'] = os.environ.get('MIQTOKEN')
+else:
+    auth['user'] = os.environ.get('MIQUSERNAME') or 'admin'
+    auth['password'] = os.environ.get('MIQPASSWORD') or 'smartvm'
 
-client = MiqApi(url, (username, password))
+
+client = MiqApi(url, auth)
 
 print("\nManageIQ version: {0}".format(client.version))
 print("\nVirtual Machines Collection\n")

--- a/testing/test_api_credentials.py
+++ b/testing/test_api_credentials.py
@@ -3,28 +3,32 @@ import mock
 
 from manageiq_client.api import ManageIQClient as MiqApi
 
+
 def test_no_user_password_auth_dict():
     with pytest.raises(KeyError):
         MiqApi('http://www.example.com', {})
+
 
 def test_no_user_password_auth_tuple():
     with pytest.raises(ValueError):
         MiqApi('http://www.example.com', "")
 
+
 def test_no_password_auth():
     with pytest.raises(KeyError):
         MiqApi('http://www.example.com', {'user': 'Fred'})
+
 
 def test_no_user_auth():
     with pytest.raises(KeyError):
         MiqApi('http://www.example.com', {'password': 'secret'})
 
+
 @mock.patch('manageiq_client.api.ManageIQClient._load_data')
 def test_user_password(self):
     MiqApi('http://www.example.com', {'user': 'Fred', 'password': 'secret'})
-    
+
+
 @mock.patch('manageiq_client.api.ManageIQClient._load_data')
 def test_token(self):
     MiqApi('http://www.example.com', {'x-auth-token': 'abcdef12345'})
-    
-     

--- a/testing/test_api_credentials.py
+++ b/testing/test_api_credentials.py
@@ -1,0 +1,30 @@
+import pytest
+import mock
+
+from manageiq_client.api import ManageIQClient as MiqApi
+
+def test_no_user_password_auth_dict():
+    with pytest.raises(KeyError):
+        MiqApi('http://www.example.com', {})
+
+def test_no_user_password_auth_tuple():
+    with pytest.raises(ValueError):
+        MiqApi('http://www.example.com', "")
+
+def test_no_password_auth():
+    with pytest.raises(KeyError):
+        MiqApi('http://www.example.com', {'user': 'Fred'})
+
+def test_no_user_auth():
+    with pytest.raises(KeyError):
+        MiqApi('http://www.example.com', {'password': 'secret'})
+
+@mock.patch('manageiq_client.api.ManageIQClient._load_data')
+def test_user_password(self):
+    MiqApi('http://www.example.com', {'user': 'Fred', 'password': 'secret'})
+    
+@mock.patch('manageiq_client.api.ManageIQClient._load_data')
+def test_token(self):
+    MiqApi('http://www.example.com', {'x-auth-token': 'abcdef12345'})
+    
+     

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py{27,33,34,35},codechecks
 deps=
     pytest
     pytest-cov
+    mock
     coveralls
 commands = py.test {posargs: -v --cov manageiq_client}
 


### PR DESCRIPTION
Fixes #3 

Pass in the X-Auth-Token as part of the auth dictionary.
    If the token exists the user, password is ignored

**Pros of Token:**
      We dont have to store userid/password in playbooks
**Cons of Token:**
     Are ephemeral in nature typically lasting for 5 minutes.
