### PR TITLE
return task entity when the response contains task_href or task_id

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -622,14 +622,10 @@ class Action(object):
             if "id" in result:
                 d["href"] = "{}/{}".format(collection._href, result["id"])
             return Entity(collection, d)
-        elif "task_href" in result or "task_id" in result:
-            collection = getattr(self.api.collections, "tasks")
+        elif "task_href" in result:
+            collection = self.api.collections.tasks
             # reuse task_href and task_id, no other data is relevant
-            d = {}
-            if result.get("task_href"):
-                d["href"] = result["task_href"]
-            if result.get("task_id"):
-                d["id"] = result["task_id"]
+            d = {"href": result.get("task_href"), "id": result.get("task_id")}
             return Entity(collection, d, incomplete=True)
         elif "message" in result:
             return result

--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -622,6 +622,15 @@ class Action(object):
             if "id" in result:
                 d["href"] = "{}/{}".format(collection._href, result["id"])
             return Entity(collection, d)
+        elif "task_href" in result or "task_id" in result:
+            collection = getattr(self.api.collections, "tasks")
+            # reuse task_href and task_id, no other data is relevant
+            d = {}
+            if result.get("task_href"):
+                d["href"] = result["task_href"]
+            if result.get("task_id"):
+                d["id"] = result["task_id"]
+            return Entity(collection, d, incomplete=True)
         elif "message" in result:
             return result
         else:


### PR DESCRIPTION
For response like
```
{
  "message": "Reverting to snapshot snpshot_X81kmpK9 for Virtual Machine id:236 name:"test-snpsh-9osd"",
  "success": True,
  "task_href": "https://<address>/api/tasks/236",
  "task_id": 236
}
```
return entity corresponding to `https://<address>/api/tasks/236`