### PR TITLE
remove buggy branch

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -625,13 +625,6 @@ class Action(object):
             d = copy(result)
             d["href"] = "{}/{}".format(self.collection._href, result["id"])
             return Entity(self.collection, d, incomplete=True)
-        # TODO: Remove the branch under this condition since it can cause bad things to happen!
-        elif "request_state" in result and "requester_id" in result:
-            collection = getattr(self.api.collections, "service_requests")
-            d = copy(result)
-            if "id" in result:
-                d["href"] = "{}/{}".format(collection._href, result["id"])
-            return Entity(collection, d)
         elif "task_href" in result:
             collection = self.api.collections.tasks
             # reuse task_href and task_id, no other data is relevant


### PR DESCRIPTION
The removed code is not working. The "href" key is required for instantiation of the ``Entity`` class. If "href" is present, this code is never reached (see branches above). Same goes for "id" that is used for construction of the "href" - if "id" is present, this code is never reached.
I.e. this code is reached only when "href" and "id" are not present and thus the ``Entity`` instantiation fails with ``ValueError``. I've never seen this to happen so it's more likely that the code is never reached.