### PR TITLE
fixing _process_result

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -617,26 +617,27 @@ class Action(object):
         return outcome
 
     def _get_entity_from_href(self, result):
+        """Returns entity in correct collection.
+
+        If the "href" value in result doesn't match the current collection,
+        try to find the collection that the "href" refers to.
+        """
         href_result = result['href']
-        href_match = None
 
-        # If the "href" value in result doesn't match the current collection,
-        # try to find the collection that the "href" refers to.
-        if self.collection._href not in href_result:
-            href_match = re.match(r"(http[^?]+)/([a-z_-]+)", href_result)
+        if self.collection._href.startswith(href_result):
+            return Entity(self.collection, result, incomplete=True)
 
-        if href_match:
-            collection_name = href_match.group(2)
-            entry_point = href_match.group(1)
-            if collection_name and entry_point:
-                new_collection = Collection(
-                    self.collection.api,
-                    "{}/{}".format(entry_point, collection_name),
-                    collection_name
-                )
-                return Entity(new_collection, result, incomplete=True)
-
-        return Entity(self.collection, result, incomplete=True)
+        href_match = re.match(r"(https?://.+/api[^?]*)/([a-z_-]+)", href_result)
+        if not href_match:
+            raise ValueError("Malformed href: {}".format(href_result))
+        collection_name = href_match.group(2)
+        entry_point = href_match.group(1)
+        new_collection = Collection(
+            self.collection.api,
+            "{}/{}".format(entry_point, collection_name),
+            collection_name
+        )
+        return Entity(new_collection, result, incomplete=True)
 
     def _process_result(self, result):
         if result is None:

--- a/testing/test_process_result.py
+++ b/testing/test_process_result.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from manageiq_client.api import Collection, ActionContainer, Action
+
+
+def test_get_entity_from_href():
+    url_base = "http://example.com/api/"
+    test_data = [
+        # resource url, expected collection name, expected collection href
+        ("rates/1/subcol/3r45/?test=/foo/bar", "subcol", "rates/1/subcol"),
+        ("service_catalogs/000/", "service_catalogs", "service_catalogs"),
+        ("service_catalogs/000/templates/123", "templates", "service_catalogs/000/templates"),
+        ("users/0000034", "users", "users"),
+        ("collection", "collection", "collection")
+    ]
+
+    collection = Collection(None, "{}collection".format(url_base), "collection")
+    action_container = ActionContainer(collection)
+    action = Action(action_container, "create", "post", "{}collection/123".format(url_base))
+
+    for url, col_name, col_href in test_data:
+        col_href = "{}{}".format(url_base, col_href)
+        result = {"href": "{}{}".format(url_base, url)}
+        entity = action._get_entity_from_href(result)
+        assert entity.collection.name == col_name
+        assert entity.collection._href == col_href
+        assert entity._href == result['href']

--- a/testing/test_process_result.py
+++ b/testing/test_process_result.py
@@ -7,7 +7,7 @@ from manageiq_client.api import Collection, ActionContainer, Action
 url_bases = [
     "https://example.com/api/v2.4.0/",
     "https://example.com/api/",
-    "https://127.0.0.1:8080//api",
+    "http://127.0.0.1:8080//api",
 ]
 
 url_variants = [

--- a/testing/test_process_result.py
+++ b/testing/test_process_result.py
@@ -27,7 +27,7 @@ malformed_urls = [
 
 
 @pytest.fixture(scope="function")
-def action(url_base="https://example.com/api"):
+def action(url_base):
     collection = Collection(None, "{}/collection".format(url_base), "collection")
     action_container = ActionContainer(collection)
     return Action(action_container, "create", "post", "{}/collection/123".format(url_base))
@@ -47,6 +47,7 @@ def test_get_entity_from_href(url_base, test_data, action):
 
 
 @pytest.mark.parametrize("test_data", malformed_urls)
+@pytest.mark.parametrize("url_base", ("https://example.com/api",), ids=['addr0'])
 def test_malformed_href(test_data, action):
     result = {"href": test_data}
     with pytest.raises(ValueError):

--- a/testing/test_process_result.py
+++ b/testing/test_process_result.py
@@ -1,26 +1,31 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from manageiq_client.api import Collection, ActionContainer, Action
 
 
-def test_get_entity_from_href():
+url_variants = [
+    # resource url, expected collection name, expected collection href
+    ("users/34", "users", "users"),
+    ("groups/1/", "groups", "groups"),
+    ("service_catalogs/42/templates/123", "templates", "service_catalogs/42/templates"),
+    ("col/1/subcol/1r45/?test=/foo/bar", "subcol", "col/1/subcol"),
+    ("collection", "collection", "collection"),
+]
+
+
+@pytest.mark.parametrize('test_data', url_variants, ids=[variant[0] for variant in url_variants])
+def test_get_entity_from_href(test_data):
     url_base = "http://example.com/api/"
-    test_data = [
-        # resource url, expected collection name, expected collection href
-        ("rates/1/subcol/3r45/?test=/foo/bar", "subcol", "rates/1/subcol"),
-        ("service_catalogs/000/", "service_catalogs", "service_catalogs"),
-        ("service_catalogs/000/templates/123", "templates", "service_catalogs/000/templates"),
-        ("users/0000034", "users", "users"),
-        ("collection", "collection", "collection")
-    ]
 
     collection = Collection(None, "{}collection".format(url_base), "collection")
     action_container = ActionContainer(collection)
     action = Action(action_container, "create", "post", "{}collection/123".format(url_base))
 
-    for url, col_name, col_href in test_data:
-        col_href = "{}{}".format(url_base, col_href)
-        result = {"href": "{}{}".format(url_base, url)}
-        entity = action._get_entity_from_href(result)
-        assert entity.collection.name == col_name
-        assert entity.collection._href == col_href
-        assert entity._href == result['href']
+    url, col_name, col_href = test_data
+    col_href = "{}{}".format(url_base, col_href)
+    result = {"href": "{}{}".format(url_base, url)}
+    entity = action._get_entity_from_href(result)
+    assert entity.collection.name == col_name
+    assert entity.collection._href == col_href
+    assert entity._href == result['href']


### PR DESCRIPTION
The response to action performed on resource(s) can contain either data corresponding to collection where the action took place, or to other collection like "service_requests", "automation_requests", etc.

We always expect that the "href" contained in the response corresponds to the collection where the action took place, which is incorrect. In case of e.g. ``service_template.action.order()``, the returned entity belongs to ``/api/collections/service_catalogs/:id/service_templates``collection instead of ``/api/service_requests`` collection where it should belong to.

The fix: select correct collection based on the "href" contained in the response.