### PR TITLE
Remove Forced SSL Warning

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -30,7 +30,6 @@ class ManageIQClient(object):
         self._build_auth(auth)
         if not verify_ssl:
             self._session.verify = False
-            warnings.filterwarnings('once', message='.*Unverified HTTPS request.*')
         elif ca_bundle_path:
             self._session.verify = ca_bundle_path
         self.logger = logger or logging.getLogger(__name__)

--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import re
-import warnings
 import requests
 import simplejson
 import six


### PR DESCRIPTION
The current implementation "forces" a single SSL warning on the client, further calls will not print warnings. It is not possible to disable the force warning via normal methods https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings  (or any other method i tried).

This causes problems in automation tools that rely on stdout/stderr.

By removing this "forced" warning, the end user can disable SSL warnings via normal methods and all of them will be suppressed.