### PR TITLE
Add possibility to specify attributes when creating Entities

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -329,12 +329,12 @@ class Collection(object):
 
     @property
     def count(self):
-        self.reload()
+        self.reload_if_needed()
         return self._count
 
     @property
     def subcount(self):
-        self.reload()
+        self.reload_if_needed()
         return self._subcount
 
     @property
@@ -408,15 +408,15 @@ class Entity(object):
         else:  # Malformed
             raise ValueError("Malformed data: {!r}".format(self._data))
 
-    def reload(self, expand=None, get=True, attributes='_default'):
+    def reload(self, expand=None, get=True, attributes=None):
         kwargs = {}
         if expand:
             if isinstance(expand, (list, tuple)):
                 expand = ",".join(map(str, expand))
             kwargs.update(expand=expand)
-        if attributes == '_default':
+        if attributes is None:
             attributes = self._attributes
-        if attributes is not None:
+        if attributes:
             if isinstance(attributes, six.string_types):
                 attributes = [attributes]
             kwargs.update(attributes=",".join(attributes))

--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -148,9 +148,10 @@ class ManageIQClient(object):
                 self, "{}/{}".format(self._entry_point, collection_or_name), collection_or_name)
         else:
             collection = collection_or_name
-        entity = Entity(collection, {"href": "{}/{}".format(collection._href, entity_id)})
-        if attributes is not None:
-            entity.reload(attributes=attributes)
+        entity = Entity(
+            collection,
+            {"href": "{}/{}".format(collection._href, entity_id)},
+            attributes=attributes)
         return entity
 
     def api_version(self, version):
@@ -257,13 +258,17 @@ class Collection(object):
                     "[RESTAPI] failed to get subcollections list for %s", self._href)
         return self._subcollections
 
-    def reload(self, expand=False):
+    def reload(self, expand=False, attributes=None):
         if expand is True:
             kwargs = {"expand": "resources"}
         elif expand:
             kwargs = {"expand": expand}
         else:
             kwargs = {}
+        if attributes is not None:
+            if isinstance(attributes, six.string_types):
+                attributes = [attributes]
+            kwargs.update(attributes=",".join(attributes))
         self._data = self._api.get(self._href, **kwargs)
         self._resources = self._data["resources"]
         self._count = self._data.get("count", 0)
@@ -324,18 +329,25 @@ class Collection(object):
 
     @property
     def count(self):
-        self.reload_if_needed()
+        self.reload()
         return self._count
 
     @property
     def subcount(self):
-        self.reload_if_needed()
+        self.reload()
         return self._subcount
 
     @property
     def all(self):
-        self.reload_if_needed()
-        return map(lambda r: Entity(self, r), self._resources)
+        self.reload(expand=True)
+        return [Entity(self, r) for r in self._resources]
+
+    def all_include_attributes(self, attributes):
+        """Returns all entities present in the collection with ``attributes`` included."""
+        self.reload(expand=True, attributes=attributes)
+        entities = [Entity(self, r, attributes=attributes) for r in self._resources]
+        self.reload()
+        return entities
 
     def __repr__(self):
         return "<Collection {!r} ({!r})>".format(self.name, self.description)
@@ -378,11 +390,12 @@ class Entity(object):
         roles={"features"},
     )
 
-    def __init__(self, collection, data, incomplete=False):
+    def __init__(self, collection, data, incomplete=False, attributes=None):
         self.collection = collection
         self.action = ActionContainer(self)
         self._data = data
         self._incomplete = incomplete
+        self._attributes = attributes
         self._href = None
         self._load_data()
 
@@ -395,12 +408,14 @@ class Entity(object):
         else:  # Malformed
             raise ValueError("Malformed data: {!r}".format(self._data))
 
-    def reload(self, expand=None, get=True, attributes=None):
+    def reload(self, expand=None, get=True, attributes='_default'):
         kwargs = {}
         if expand:
             if isinstance(expand, (list, tuple)):
                 expand = ",".join(map(str, expand))
             kwargs.update(expand=expand)
+        if attributes == '_default':
+            attributes = self._attributes
         if attributes is not None:
             if isinstance(attributes, six.string_types):
                 attributes = [attributes]

--- a/testing/test_miqapi.py
+++ b/testing/test_miqapi.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+import re
+
+import pytest
+
+from httmock import all_requests, HTTMock
+from manageiq_client.api import ManageIQClient as MiqApi
+
+
+API_CONTENT = {
+    "name": "API",
+    "description": "REST API",
+    "version": "2.4.0",
+    "versions": [
+        {
+            "name": "2.4.0",
+            "href": "http://www.test.com/api/v2.4.0"
+        }
+    ],
+    "collections": [
+        {
+            "name": "servers",
+            "href": "https://www.test.com/api/servers",
+            "description": "EVM Servers"
+        }
+    ]
+}
+
+SERVERS_CONTENT = {
+    "name": "servers",
+    "count": 1,
+    "subcount": 1,
+    "resources": [
+        {
+            "href": "https://www.test.com/api/servers/1"
+        }
+    ]
+}
+
+SERVERS_W_ATTRIBUTES_CONTENT = {
+    "name": "servers",
+    "count": 1,
+    "subcount": 1,
+    "resources": [
+        {
+            "href": "https://www.test.com/api/servers/1",
+            "id": 1,
+            "name": "EVM",
+            "region_number": 0
+        }
+    ]
+}
+
+SERVER_ENTITY_CONTENT = {
+    "href": "https://www.test.com/api/servers/1",
+    "id": 1,
+    "name": "EVM"
+}
+
+SERVER_ENTITY_W_ATTRIBUTES_CONTENT = {
+    "href": "https://www.test.com/api/servers/1",
+    "id": 1,
+    "name": "EVM",
+    "region_number": 0
+}
+
+
+@all_requests
+def api_mock(url, request):
+    return {'status_code': 200,
+            'content': API_CONTENT}
+
+
+@all_requests
+def servers_mock(url, request):
+    entity_matched = re.match(r'/api[^?]*/[0-9]+', request.path_url)
+    attributes_present = 'attributes' in request.path_url
+    response = {'status_code': 200}
+
+    if entity_matched and attributes_present:
+        response['content'] = SERVER_ENTITY_W_ATTRIBUTES_CONTENT
+    elif entity_matched:
+        response['content'] = SERVER_ENTITY_CONTENT
+    elif attributes_present:
+        response['content'] = SERVERS_W_ATTRIBUTES_CONTENT
+    else:
+        response['content'] = SERVERS_CONTENT
+    return response
+
+
+@pytest.fixture(scope='module')
+def api():
+    with HTTMock(api_mock):
+        api = MiqApi('http://www.test.com/api', ('admin', 'admin'), verify_ssl=False)
+    return api
+
+
+class TestEntities(object):
+    def test_get_all(self, api):
+        with HTTMock(servers_mock):
+            srv = api.collections.servers.all[0]
+            # cannot use hasattr here because it would try
+            # to look for 'region_number' subcollection
+            assert 'region_number' not in srv.__dict__
+            srv.reload()
+            assert 'region_number' not in srv.__dict__
+
+    def test_get_all_w_attributes_str(self, api):
+        with HTTMock(servers_mock):
+            srv = api.collections.servers.all_include_attributes('region_number')[0]
+            assert srv._attributes == 'region_number'
+            assert srv.region_number == 0
+            srv.reload()
+            assert srv.region_number == 0
+
+    def test_get_all_w_attributes_list(self, api):
+        with HTTMock(servers_mock):
+            srv = api.collections.servers.all_include_attributes(['region_number'])[0]
+            assert srv._attributes[0] == 'region_number'
+            assert srv.region_number == 0
+            srv.reload()
+            assert srv.region_number == 0
+
+    def test_get_entity_from_api(self, api):
+        with HTTMock(servers_mock):
+            srv = api.get_entity('servers', 1)
+            srv.reload()
+            assert 'region_number' not in srv.__dict__
+
+    def test_get_entity_from_collection(self, api):
+        with HTTMock(servers_mock):
+            srv = api.collections.servers(1)
+            srv.reload()
+            assert 'region_number' not in srv.__dict__
+
+    def test_get_entity_w_attributes_from_api(self, api):
+        with HTTMock(servers_mock):
+            srv = api.get_entity('servers', 1, 'region_number')
+            assert srv._attributes == 'region_number'
+            assert srv.region_number == 0
+            srv.reload()
+            assert srv.region_number == 0
+
+    def test_get_entity_w_attributes_from_collection(self, api):
+        with HTTMock(servers_mock):
+            srv = api.collections.servers(1, 'region_number')
+            assert srv._attributes == 'region_number'
+            assert srv.region_number == 0
+            srv.reload()
+            assert srv.region_number == 0


### PR DESCRIPTION
* adds possibility to specify additional attributes for the Entity and make them persistent, so they are not lost when Entity is reloaded
* adds ``Collection.all_include_attributes`` method. This if useful when specific virtual attribute for all Entities is needed. Now it would require smtg like:
```python
for entity in collection.all:
    entity.reload(attributes=['attr1', 'attr2']
    entity_action(entity)
```
As a result, new GET is called for every entity.
With this change,
```python
for entity in collection.all_include_attributes(['attr1', 'attr2']):
    entity_action(entity)
```
is enough and it's all handled with single GET.
* for ``Collection``, do ``reload()`` for ``count``, ``subcount`` and ``all`` properties so we always have up-to-date data (the ``reload_if_needed`` will not GET up-to-date data if data were already loaded in the past).
Not sure about ``__getitem__``, as it might be too expensive to do ``reload()`` every time before getting single entity. For now I left it untouched.