### PR TITLE
Drop testing on 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 install: pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Intended Audience :: Developers",


### PR DESCRIPTION
... as up-to-date pytest requires Python3 >= 3.4
See https://travis-ci.org/ManageIQ/manageiq-api-client-python/jobs/322739550