### PR TITLE
fix recursion error when getting an invalid action object attribute

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -587,7 +587,7 @@ class ActionContainer(object):
 
     def __getattr__(self, attr):
         self.reload()
-        if not hasattr(self, attr):
+        if attr not in self.__dict__:
             raise AttributeError("No such action {}".format(attr))
         return getattr(self, attr)
 

--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -589,7 +589,7 @@ class ActionContainer(object):
         self.reload()
         if attr not in self.__dict__:
             raise AttributeError("No such action {}".format(attr))
-        return getattr(self, attr)
+        return self.__dict__[attr]
 
     def __contains__(self, action):
         return action in self.all

--- a/testing/test_actions.py
+++ b/testing/test_actions.py
@@ -162,6 +162,17 @@ class TestActionMethods(object):
             assert hasattr(service.action.delete, 'POST')
             assert hasattr(service.action.delete, 'DELETE')
 
+    def test_actions_absent(self, api):
+        with HTTMock(services_mock), pytest.raises(AttributeError) as excinfo:
+            services = api.collections.services
+            services.reload()
+            getattr(services.action, 'foo')
+        assert 'No such action foo' == str(excinfo.value)
+        with HTTMock(service_mock), pytest.raises(AttributeError) as excinfo:
+            service = api.collections.services[0]
+            getattr(service.action, 'foo')
+        assert 'No such action foo' == str(excinfo.value)
+
     def test_edit_patch(self, service, captured_log):
         with HTTMock(service_mock):
             outcome = service.action.edit.PATCH({


### PR DESCRIPTION
This commit updates the ActionContainer __getattr__ method to not use
hasattr to determine if the attribute does not exist. When running
with Python 3, this was causing the method to call itself since
hasattr calls getattr. This update will remove using hasattr and
now use the in keyword. Now if action getattr is called with an
invalid attribute, an attribute error will be rasied.

Closes #33