### PR TITLE
FIX: Skip null values when processing attributes

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -438,6 +438,8 @@ class Entity(object):
                 self._data.update(new)
         self._actions = self._data.pop("actions", [])
         for key, value in self._data.items():
+            if value is None:
+                continue
             if key in self.TIME_FIELDS:
                 setattr(self, key, iso8601.parse_date(value))
             elif key in self.COLLECTION_MAPPING.keys():


### PR DESCRIPTION
On current upstream attributes in responses contain ``null`` values. This makes our library fail:
```
        if not isinstance(datestring, _basestring):
>           raise ParseError("Expecting a string %r" % datestring)
E           ParseError: Expecting a string None
```
The response now looks like
```json
{
    "results": [
        {
            "ancestry": null,
            "created_at": "2018-04-04T10:04:38Z",
            "description": null,
            "display": false,
            "evm_owner_id": null,
            "guid": "a608b1cd-b248-4894-8e2d-855911de1462",
            "href": "https://addr/api/services/1",
            "id": "1",
            "initiator": "user",
            "miq_group_id": "2",
            "name": "myservice01",
            "options": {},
            "retired": false,
            "retirement_last_warn": null,
            "retirement_requester": null,
            "retirement_state": null,
            "retirement_warn": null,
            "retires_on": null,
            "service_template_id": null,
            "tenant_id": "1",
            "type": null,
            "updated_at": "2018-04-04T10:04:38Z"
        }
    ]
}
```

This fix skips attributes with ``null`` values when processing response data.