### PR TITLE
Add expand and attributes to get and filter methods

### DIFF
--- a/src/manageiq_client/api.py
+++ b/src/manageiq_client/api.py
@@ -225,7 +225,7 @@ class SearchResult(object):
 
     def __getitem__(self, position):
         entity = self.resources[position]
-        entity.reload()
+        entity._load_data()
         return entity
 
     def __len__(self):
@@ -309,7 +309,7 @@ class Collection(object):
 
         Returns: :py:class:`SearchResult`
         """
-        return SearchResult(self, self._api.get(self._href, **{"filter[]": filters}), attributes=attributes, expand=expand)
+        return SearchResult(self, self._api.get(self._href, **{"filter[]": filters, "attributes": attributes, "expand": expand}), attributes=attributes, expand=expand)
 
     def filter(self, q, attributes=None, expand=None):
         """Access the ``filter[]`` functionality of ManageIQ.


### PR DESCRIPTION
I have ran into the problem numerous times where I need to `.get(id=XXX)` or some filter but I also want some extended attributes on the objects. The way the current structure is laid out, I can get the results. These results are then all loaded with data. 

As I iterate through my results I need to call `reload(expand=xxx,attributes=yyyy)`. 

These change adds support for expand and attributes to search results so that the secondary reload is not required.

Side effect of using expand is you get additional Entities on the object. These objects when accessed are type `dict` and not type `Entity` which causes a difference in usage of the api.

As an example when I query a service and expand vms, I can call `service.vms` and it will return type `List[dict]`. With the changes here it will look to see if the object has an `href` property. If it does, it will wrap it up as an Entity so `service.vms` will return type `List[Entity]` and allow familiar usage of the api.