### PR TITLE
Update tooling for release and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,76 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-venv/
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
 build/
+develop-eggs/
+dist/
+downloads/
+eggs/
 .eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+
+.pytest_cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
 install: pip install tox-travis
 script: tox
 # TODO: Once coveralls is enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
+- '3.6'
 install: pip install tox-travis
 script: tox
 # TODO: Once coveralls is enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7'
 install: pip install tox-travis
 script: tox
 # TODO: Once coveralls is enabled

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+-e .
+
+coveralls
+httmock
+mock
+pytest
+pytest-cov
+tox

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Intended Audience :: Developers",
         "Development Status :: 3 - Alpha",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,9 @@
 [tox]
-envlist = py{27,33,34,35},codechecks
+envlist = py{27,34,35,36,37},codechecks
 
 [testenv]
-deps=
-    coveralls
-    httmock
-    mock
-    pytest
-    pytest-cov
-commands = py.test {posargs: -v --cov manageiq_client}
+deps = -rrequirements.txt
+commands = py.test {posargs: -vv --cov-report term --cov manageiq_client}
 
 [testenv:codechecks]
 skip_install = true
@@ -20,6 +15,26 @@ max_line_length = 100
 
 [tox:travis]
 2.7 = py27, codechecks
-3.3 = py33
 3.4 = py34
 3.5 = py35
+3.6 = py36
+
+# Release tooling
+[testenv:build]
+basepython = python3
+skip_install = true
+deps =
+    wheel
+    setuptools
+commands =
+    python setup.py -q sdist bdist_wheel
+
+[testenv:release]
+basepython = python3
+skip_install = true
+deps =
+    {[testenv:build]deps}
+    twine >= 1.5.0
+commands =
+    {[testenv:build]commands}
+    twine upload --skip-existing dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,9 @@ commands = flake8 {posargs:src testing}
 [flake8]
 max_line_length = 100
 
-[tox:travis]
-2.7 = py27, codechecks
-3.4 = py34
-3.5 = py35
-3.6 = py36
+[travis]
+python =
+    2.7: py27, codechecks
 
 # Release tooling
 [testenv:build]


### PR DESCRIPTION
* updates `.gitignore` to include other files we don't want to have in the repo
* adds python 3.6 to run tests on travis (3.7 is new and still little bit problematic on travis)
* updates supported python versions in `setup.py`
* adds development dependencies to `requirements.txt`
* adds "build" and "release" targets to `tox` to simplify release process